### PR TITLE
Fix buildSrc compile when no maven cache.

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,6 +2,11 @@ plugins {
     `kotlin-dsl`
 }
 
+repositories {
+    mavenCentral()
+    gradlePluginPortal()
+}
+
 //
 //gradlePlugin{
 //    plugins {


### PR DESCRIPTION
Sub-module named `buildSrc` was not included by the root project, so the `allprojects`.`repositories` block won't apply to it.  
It causes a fail in configuring the project.