### PR TITLE
reintroduce ```whitelist list [verbose]``` (fix #104)

### DIFF
--- a/core/src/main/java/moe/caa/multilogin/core/command/Permissions.java
+++ b/core/src/main/java/moe/caa/multilogin/core/command/Permissions.java
@@ -14,6 +14,8 @@ public final class Permissions {
     public static final String COMMAND_MULTI_LOGIN_ERASE_USERNAME = "command.multilogin.eraseusername";
     public static final String COMMAND_MULTI_LOGIN_WHITELIST_ADD = "command.multilogin.whitelist.add";
     public static final String COMMAND_MULTI_LOGIN_WHITELIST_REMOVE = "command.multilogin.whitelist.remove";
+    public static final String COMMAND_MULTI_LOGIN_WHITELIST_LIST = "command.multilogin.whitelist.list";
+    public static final String COMMAND_MULTI_LOGIN_WHITELIST_LIST_VERBOSE = "command.multilogin.whitelist.list.verbose";
     public static final String COMMAND_MULTI_LOGIN_WHITELIST_SPECIFIC_ADD = "command.multilogin.whitelist.specific.add";
     public static final String COMMAND_MULTI_LOGIN_WHITELIST_SPECIFIC_REMOVE = "command.multilogin.whitelist.specific.remove";
     public static final String COMMAND_MULTILOGIN_RENAME_ONESELF = "command.multilogin.rename.oneself";

--- a/core/src/main/java/moe/caa/multilogin/core/command/UniversalCommandExceptionType.java
+++ b/core/src/main/java/moe/caa/multilogin/core/command/UniversalCommandExceptionType.java
@@ -5,7 +5,6 @@ import com.mojang.brigadier.LiteralMessage;
 import com.mojang.brigadier.Message;
 import com.mojang.brigadier.exceptions.CommandExceptionType;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 

--- a/core/src/main/java/moe/caa/multilogin/core/command/commands/MWhitelistCommand.java
+++ b/core/src/main/java/moe/caa/multilogin/core/command/commands/MWhitelistCommand.java
@@ -193,7 +193,7 @@ public class MWhitelistCommand {
 
         var cache = CommandHandler.getCore().getCacheWhitelistHandler().getCachedWhitelist();
         context.getSource().sendMessagePL(CommandHandler.getCore().getLanguageHandler().getMessage(
-            "command_message_whitelist_cache",
+            "command_message_whitelist_list_cache",
             new Pair<>("list", cache.stream().collect(Collectors.joining(", "))),
             new Pair<>("count", cache.size())
         ));

--- a/core/src/main/resources/message.properties
+++ b/core/src/main/resources/message.properties
@@ -46,8 +46,8 @@ command_message_whitelist_permanent_add_repeat=§c使用 §e{service_name}§8(si
 command_message_whitelist_permanent_remove_repeat=§c使用 §e{service_name}§8(sid = §e{service_id}§8)§c 进行登录的玩家 §8(§e{online_name}§8)[§e{online_uuid}§8] §c没有白名单，请不要重复移除。
 command_message_whitelist_permanent_add=§a已为使用 §e{service_name}§8(sid = §e{service_id}§8)§a 进行登录的玩家 §8(§e{online_name}§8)[§e{online_uuid}§8]§a 添加白名单。
 command_message_whitelist_permanent_remove=§a使用 §e{service_name}§8(sid = §e{service_id}§8)§a 进行登录的玩家 §8[§e{online_uuid}§8](§e{online_name}§8)§a的白名单删除成功。
-command_message_whitelist_list_table=白名单数据表共有 {count} 条:\n {list}
-command_message_whitelist_list_cache=缓冲白名单共有 {count} 条数据:\n {list}
+command_message_whitelist_list_table=白名单数据表共有 {count} 条:\n{list}
+command_message_whitelist_list_cache=缓冲白名单共有 {count} 条数据:\n{list}
 command_message_erase_username_none=§c当前档案名 §e{name}§c 还没有被任何档案使用。
 command_message_erase_username_done=§a已回收档案名 §e{name}§a 。
 command_message_erase_username_desc=§c回收档案名 §e{name}§c 提供给别的档案使用。

--- a/core/src/main/resources/message.properties
+++ b/core/src/main/resources/message.properties
@@ -46,6 +46,8 @@ command_message_whitelist_permanent_add_repeat=§c使用 §e{service_name}§8(si
 command_message_whitelist_permanent_remove_repeat=§c使用 §e{service_name}§8(sid = §e{service_id}§8)§c 进行登录的玩家 §8(§e{online_name}§8)[§e{online_uuid}§8] §c没有白名单，请不要重复移除。
 command_message_whitelist_permanent_add=§a已为使用 §e{service_name}§8(sid = §e{service_id}§8)§a 进行登录的玩家 §8(§e{online_name}§8)[§e{online_uuid}§8]§a 添加白名单。
 command_message_whitelist_permanent_remove=§a使用 §e{service_name}§8(sid = §e{service_id}§8)§a 进行登录的玩家 §8[§e{online_uuid}§8](§e{online_name}§8)§a的白名单删除成功。
+command_message_whitelist_list_table=白名单数据表共有 {count} 条:\n {list}
+command_message_whitelist_list_cache=缓冲白名单共有 {count} 条数据:\n {list}
 command_message_erase_username_none=§c当前档案名 §e{name}§c 还没有被任何档案使用。
 command_message_erase_username_done=§a已回收档案名 §e{name}§a 。
 command_message_erase_username_desc=§c回收档案名 §e{name}§c 提供给别的档案使用。


### PR DESCRIPTION
adds functionality to list whitelist contents in the userdata table & cache.

- ```whitelist list```: lists player names in the userdata table & cache.

```
[17:07:14] 白名单数据表共有 2 条数据:
[17:07:14] airqt_, Pairman
[17:07:14] 缓冲白名单共有 2 条数据:
[17:07:14] yikes, bruh
```

- ```whitelist list verbose```: similar, but more verbose (containing service ids & names, online uuids and in-game profile uuids) for entries in the userdata table.

```
[17:07:14] 白名单数据表共有 2 条数据:
[17:07:14] airqt_ (service_id=1(Official), online_uuid=9fa66d14-8910-4be4-89a4-89dbcf7f6fa2, in_game_profile_uuid=9fa66d14-8910-4be4-89a4-89dbcf7f6fa2), 
[17:07:14] Pairman (service_id=1(Official), online_uuid=77ced09e-b781-41b4-a76c-e44f87b6b1c6, in_game_profile_uuid=77ced09e-b781-41b4-a76c-e44f87b6b1c6)
[17:07:14] 缓冲白名单共有 2 条数据:
[17:07:14] yikes, bruh
```

the wiki should be updated too.