### PR TITLE
支持正版验证指定自定义 Session 验证服务器地址

### DIFF
--- a/core/src/main/java/moe/caa/multilogin/core/configuration/PluginConfig.java
+++ b/core/src/main/java/moe/caa/multilogin/core/configuration/PluginConfig.java
@@ -214,9 +214,10 @@ public class PluginConfig {
             ProxyConfig authProxy = ProxyConfig.read(yggdrasilAuthNode.node("authProxy"));
 
             if (serviceType == ServiceType.OFFICIAL) {
-                return new OfficialYggdrasilServiceConfig(id, name,
+                String customSessionServer = yggdrasilAuthNode.node("official").node("sessionServer").getString("https://sessionserver.mojang.com");
+		        return new OfficialYggdrasilServiceConfig(id, name,
                         initUUID,initNameFormat, whitelist,
-                        skinRestorer, trackIp, timeout, retry, retryDelay, authProxy);
+                        skinRestorer, trackIp, timeout, retry, retryDelay, authProxy, customSessionServer);
             }
 
             if (serviceType == ServiceType.BLESSING_SKIN) {

--- a/core/src/main/java/moe/caa/multilogin/core/configuration/service/yggdrasil/OfficialYggdrasilServiceConfig.java
+++ b/core/src/main/java/moe/caa/multilogin/core/configuration/service/yggdrasil/OfficialYggdrasilServiceConfig.java
@@ -10,20 +10,21 @@ import org.jetbrains.annotations.NotNull;
  * 正版官方 Yggdrasil
  */
 public class OfficialYggdrasilServiceConfig extends BaseYggdrasilServiceConfig {
-    public OfficialYggdrasilServiceConfig(int id, String name, InitUUID initUUID, String initNameFormat, boolean whitelist, SkinRestorerConfig skinRestorer, boolean trackIp, int timeout, int retry, long retryDelay, ProxyConfig authProxy) throws ConfException {
+    private final String customSessionServer;
+
+    public OfficialYggdrasilServiceConfig(int id, String name, InitUUID initUUID, String initNameFormat, boolean whitelist, SkinRestorerConfig skinRestorer, boolean trackIp, int timeout, int retry, long retryDelay, ProxyConfig authProxy, String customSessionServer) throws ConfException {
         super(id, name, initUUID, initNameFormat, whitelist, skinRestorer, trackIp, timeout, retry, retryDelay, authProxy);
+        if (!customSessionServer.endsWith("/")) {
+            customSessionServer = customSessionServer.concat("/");
+        }
+        this.customSessionServer = customSessionServer;
     }
+
 
     @Override
     protected String getAuthURL() {
-        return "https://".concat("session")
-                .concat("server.")
-                .concat("mojang")
-                .concat(".com")
-                .concat("/session")
-                .concat("/minecraft")
-                .concat("/hasJoined?")
-                .concat("username={0}&serverId={1}{2}");
+	    String baseUrl = customSessionServer;
+	    return baseUrl.concat("session/minecraft/hasJoined?username={0}&serverId={1}{2}");
     }
 
     @Override

--- a/core/src/main/resources/examples/template_cn_full.yml
+++ b/core/src/main/resources/examples/template_cn_full.yml
@@ -71,6 +71,14 @@ yggdrasilAuth:
   # 默认值 ‘0’
   retryDelay: 0
 
+  # OFFCIAL 专用设置。
+  #
+  # 仅当 serviceType 为 OFFICIAL 时，此配置片段有效。
+  official:
+
+    # 可选，指定自定义 Session 验证服务器地址。
+    sessionServer: 'https://sessionserver.example.com'
+
   # BLESSING_SKIN 专用设置。
   #
   # 仅当 serviceType 为 BLESSING_SKIN 时，此配置片段有效。


### PR DESCRIPTION
Velocity 原本支持在启动参数修改mojang.sessionserver为自定义地址。在网络环境不佳、[官方地址](https://sessionserver.mojang.com)难以访问时，可以通过反代服务器进行正版身份验证。
此修改后，对于正版验证，默认仍采用官方地址，但可在服务配置文件中配置如 `https://sessionserver.example.com` 的自定义Session 验证服务器地址。
示例配置：
![image](https://github.com/user-attachments/assets/3d898f6f-8a51-45bb-b8f4-e07b44b17e87)

